### PR TITLE
clang-format CommitBatchContext initializer list

### DIFF
--- a/fdbserver/commitproxy/CommitProxyServer.cpp
+++ b/fdbserver/commitproxy/CommitProxyServer.cpp
@@ -747,8 +747,7 @@ CommitBatchContext::CommitBatchContext(ProxyCommitData* const pProxyCommitData_,
                                        const int currentBatchMemBytesCount)
   : pProxyCommitData(pProxyCommitData_), trs(std::move(*const_cast<std::vector<CommitTransactionRequest>*>(trs_))),
     currentBatchMemBytesCount(currentBatchMemBytesCount), startTime(g_network->now()),
-    timerStartTime(g_network->timer()),
-    localBatchNumber(++pProxyCommitData->localCommitBatchesStarted),
+    timerStartTime(g_network->timer()), localBatchNumber(++pProxyCommitData->localCommitBatchesStarted),
     toCommit(pProxyCommitData->logSystem, pProxyCommitData->localTLogCount), span("MP:commitBatch"_loc),
     committed(trs.size()), lastShardMove(invalidVersion) {
 


### PR DESCRIPTION
Fixes the failing `clang-format` check on apple/foundationdb#13416.

The new `timerStartTime` member split the `CommitBatchContext` initializer list at a point clang-format wants packed:

```
-    timerStartTime(g_network->timer()),
-    localBatchNumber(++pProxyCommitData->localCommitBatchesStarted),
+    timerStartTime(g_network->timer()), localBatchNumber(++pProxyCommitData->localCommitBatchesStarted),
```

Joined line is 104 columns, under the 120 limit. This is the only formatting drift in the PR — the other three C++ files are already clean.

Merging this into `main-commit-metrics` should turn apple/foundationdb#13416 green. Alternatively just run `clang-format -i fdbserver/commitproxy/CommitProxyServer.cpp` yourself and skip this PR.

Note: CI uses clang-format-19; I verified with 22.1.2 locally. A bin-packing join of two short lines is stable across versions, and v22 reports the PR's other files clean, so it agrees with the repo's `.clang-format` on existing code.